### PR TITLE
Avoid duplicated fields when embedding

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -8,19 +8,18 @@ import (
 // ReaderCounter is counter for io.Reader
 type ReaderCounter struct {
 	io.Reader
-	count  uint64
-	reader io.Reader
+	count uint64
 }
 
 // NewReaderCounter function for create new ReaderCounter
 func NewReaderCounter(r io.Reader) *ReaderCounter {
 	return &ReaderCounter{
-		reader: r,
+		Reader: r,
 	}
 }
 
 func (counter *ReaderCounter) Read(buf []byte) (int, error) {
-	n, err := counter.reader.Read(buf)
+	n, err := counter.Reader.Read(buf)
 	atomic.AddUint64(&counter.count, uint64(n))
 	return n, err
 }

--- a/response_writer.go
+++ b/response_writer.go
@@ -14,34 +14,33 @@ type ResponseWriterCounter struct {
 	http.ResponseWriter
 	count   uint64
 	started time.Time
-	writer  http.ResponseWriter
 }
 
 // NewResponseWriterCounter function create new ResponseWriterCounter
 func NewResponseWriterCounter(rw http.ResponseWriter) *ResponseWriterCounter {
 	return &ResponseWriterCounter{
-		writer: rw,
-		started: time.Now(),
+		ResponseWriter: rw,
+		started:        time.Now(),
 	}
 }
 
 func (counter *ResponseWriterCounter) Write(buf []byte) (int, error) {
-	n, err := counter.writer.Write(buf)
+	n, err := counter.ResponseWriter.Write(buf)
 	atomic.AddUint64(&counter.count, uint64(n))
 	return n, err
 }
 
 func (counter *ResponseWriterCounter) Header() http.Header {
-	return counter.writer.Header()
+	return counter.ResponseWriter.Header()
 }
 
 func (counter *ResponseWriterCounter) WriteHeader(statusCode int) {
 	counter.Header().Set("X-Runtime", fmt.Sprintf("%.6f", time.Since(counter.started).Seconds()))
-	counter.writer.WriteHeader(statusCode)
+	counter.ResponseWriter.WriteHeader(statusCode)
 }
 
 func (counter *ResponseWriterCounter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return counter.writer.(http.Hijacker).Hijack()
+	return counter.ResponseWriter.(http.Hijacker).Hijack()
 }
 
 // Count function return counted bytes

--- a/writer.go
+++ b/writer.go
@@ -8,19 +8,18 @@ import (
 // WriterCounter is counter for io.Writer
 type WriterCounter struct {
 	io.Writer
-	count  uint64
-	writer io.Writer
+	count uint64
 }
 
 // NewWriterCounter function create new WriterCounter
 func NewWriterCounter(w io.Writer) *WriterCounter {
 	return &WriterCounter{
-		writer: w,
+		Writer: w,
 	}
 }
 
 func (counter *WriterCounter) Write(buf []byte) (int, error) {
-	n, err := counter.writer.Write(buf)
+	n, err := counter.Writer.Write(buf)
 	atomic.AddUint64(&counter.count, uint64(n))
 	return n, err
 }


### PR DESCRIPTION
Previously the embedded fields were not used and methods were
unnecessarily overridden.