### PR TITLE
added a response_reader that tracks response body size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/miolini/datacounter
+module github.com/shmul/datacounter
 
 go 1.11

--- a/response_reader.go
+++ b/response_reader.go
@@ -25,7 +25,7 @@ func (counter *ResponseBodyCounter) Read(buf []byte) (int, error) {
 	return n, err
 }
 
-// Read invokes the underlying Closer
+// Close invokes the underlying Closer
 func (counter *ResponseBodyCounter) Close() error {
 	return counter.ReadCloser.Close()
 }

--- a/response_reader.go
+++ b/response_reader.go
@@ -1,0 +1,36 @@
+package datacounter
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// ResponseBodyCounter is counter for ReadCloser primarily targeted at wrapping http.Request Body
+type ResponseBodyCounter struct {
+	io.ReadCloser
+	count uint64
+}
+
+// NewResponseBodyCounter function for create new ResponseBodyCounter
+func NewResponseBodyCounter(r io.ReadCloser) *ResponseBodyCounter {
+	return &ResponseBodyCounter{
+		ReadCloser: r,
+	}
+}
+
+// Read invokes the underlying Reader
+func (counter *ResponseBodyCounter) Read(buf []byte) (int, error) {
+	n, err := counter.ReadCloser.Read(buf)
+	atomic.AddUint64(&counter.count, uint64(n))
+	return n, err
+}
+
+// Read invokes the underlying Closer
+func (counter *ResponseBodyCounter) Close() error {
+	return counter.ReadCloser.Close()
+}
+
+// Count function return counted bytes
+func (counter *ResponseBodyCounter) Count() uint64 {
+	return atomic.LoadUint64(&counter.count)
+}


### PR DESCRIPTION
Similar to a previous request that failed due to missing function comments. These were added. I hope you'll find these useful.