### PR TITLE
Tiny bugfixing

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -20,7 +20,18 @@ func NewReaderCounter(r io.Reader) *ReaderCounter {
 
 func (counter *ReaderCounter) Read(buf []byte) (int, error) {
 	n, err := counter.Reader.Read(buf)
-	atomic.AddUint64(&counter.count, uint64(n))
+
+	// Read() should always return a non-negative `n`.
+	// But since `n` is a signed integer, some custom
+	// implementation of an io.Reader may return negative
+	// values.
+	//
+	// Excluding such invalid values from counting,
+	// thus `if n >= 0`:
+	if n >= 0 {
+		atomic.AddUint64(&counter.count, uint64(n))
+	}
+
 	return n, err
 }
 

--- a/reader.go
+++ b/reader.go
@@ -7,8 +7,8 @@ import (
 
 // ReaderCounter is counter for io.Reader
 type ReaderCounter struct {
-	io.Reader
 	count uint64
+	io.Reader
 }
 
 // NewReaderCounter function for create new ReaderCounter

--- a/writer.go
+++ b/writer.go
@@ -20,7 +20,18 @@ func NewWriterCounter(w io.Writer) *WriterCounter {
 
 func (counter *WriterCounter) Write(buf []byte) (int, error) {
 	n, err := counter.Writer.Write(buf)
-	atomic.AddUint64(&counter.count, uint64(n))
+
+	// Write() should always return a non-negative `n`.
+	// But since `n` is a signed integer, some custom
+	// implementation of an io.Writer may return negative
+	// values.
+	//
+	// Excluding such invalid values from counting,
+	// thus `if n >= 0`:
+	if n >= 0 {
+		atomic.AddUint64(&counter.count, uint64(n))
+	}
+
 	return n, err
 }
 

--- a/writer.go
+++ b/writer.go
@@ -7,8 +7,8 @@ import (
 
 // WriterCounter is counter for io.Writer
 type WriterCounter struct {
-	io.Writer
 	count uint64
+	io.Writer
 }
 
 // NewWriterCounter function create new WriterCounter


### PR DESCRIPTION
Fixing two problems:
* Fixing the atomicity of `count` on ARM, 386 and MIPS32.
* Ignoring negative `n` values (in case of a custom `io.Reader`/`io.Writer` which breaks the expectations and returns for example `-1` on errors).