### PR TITLE
Add Unwrap method to ResponseWriter

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -63,3 +63,8 @@ func (counter *ResponseWriterCounter) Started() time.Time {
 func (counter *ResponseWriterCounter) StatusCode() int {
 	return counter.statusCode
 }
+
+// Unwrap returns the underlying ResponseWriter
+func (counter *ResponseWriterCounter) Unwrap() http.ResponseWriter {
+	return counter.ResponseWriter
+}


### PR DESCRIPTION
Go v1.20 adds a [ResponseController](https://pkg.go.dev/net/http#ResponseController) that requires direct access to the `ResponseWriter` or an `Unwrap` method that returns it.

Add an `Unwrap` method to return the underlying `ResponseWriter` so that it can be used in `http.NewResponseController` calls.